### PR TITLE
client: add prayerflicker, interacthighlight plugins

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\there\.android\avd\Nexus_5_API_30.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-29T04:20:39.023990500Z" />
+  </component>
+</project>

--- a/api/src/main/java/net/runelite/api/Prayer.java
+++ b/api/src/main/java/net/runelite/api/Prayer.java
@@ -155,16 +155,16 @@ public enum Prayer
 	/**
 	 * Gets the varbit that stores whether the prayer is active or not.
 	 */
-	private final int varbit;
+	public final int varbit;
 
 	/**
 	 * Gets the prayer drain rate (measured in pray points/minute)
 	 */
-	private final double drainRate;
+	public final double drainRate;
 
 	/**
 	 * Gets the widget info for prayer
 	 */
-	private final WidgetInfo widgetInfo;
+	public final WidgetInfo widgetInfo;
 
 }

--- a/api/src/main/java/net/runelite/api/VarClientStr.java
+++ b/api/src/main/java/net/runelite/api/VarClientStr.java
@@ -46,5 +46,5 @@ public enum VarClientStr
 	NOTIFICATION_TOP_TEXT(387),
 	NOTIFICATION_BOTTOM_TEXT(388);
 
-	private final int index;
+	public final int index;
 }

--- a/app/src/main/java/dev/hoot/api/game/Skills.java
+++ b/app/src/main/java/dev/hoot/api/game/Skills.java
@@ -1,0 +1,24 @@
+package dev.hoot.api.game;
+
+import net.runelite.api.Skill;
+
+import meteor.Main;
+
+public class Skills
+{
+
+	public static int getBoostedLevel(Skill skill)
+	{
+		return Main.client.getBoostedSkillLevel(skill);
+	}
+
+	public static int getLevel(Skill skill)
+	{
+		return Main.client.getRealSkillLevel(skill);
+	}
+
+	public static int getExperience(Skill skill)
+	{
+		return Main.client.getSkillExperience(skill);
+	}
+}

--- a/app/src/main/java/dev/hoot/api/game/Vars.java
+++ b/app/src/main/java/dev/hoot/api/game/Vars.java
@@ -1,0 +1,35 @@
+package dev.hoot.api.game;
+
+import net.runelite.api.VarClientInt;
+import net.runelite.api.VarClientStr;
+import net.runelite.api.Varbits;
+
+import meteor.Main;
+
+public class Vars
+{
+	public static int getBit(int id)
+	{
+		return GameThread.invokeLater(() -> Main.client.getVarbitValue(Main.client.getVarps(), id));
+	}
+
+	public static int getBit(Varbits varbits)
+	{
+		return getBit(varbits);
+	}
+
+	public static int getVarp(int id)
+	{
+		return Main.client.getVarpValue(Main.client.getVarps(), id);
+	}
+
+	public static int getVarcInt(VarClientInt varClientInt)
+	{
+		return Main.client.getVarcIntValue(varClientInt.index);
+	}
+
+	public static String getVarcStr(VarClientStr varClientStr)
+	{
+		return Main.client.getVarcStrValue(varClientStr.index);
+	}
+}

--- a/app/src/main/java/dev/hoot/api/packets/WidgetPackets.java
+++ b/app/src/main/java/dev/hoot/api/packets/WidgetPackets.java
@@ -5,6 +5,8 @@ import net.runelite.api.packets.PacketBufferNode;
 import net.runelite.api.widgets.Widget;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 public class WidgetPackets
 {
@@ -261,5 +263,37 @@ public class WidgetPackets
 	public static PacketBufferNode createContinuePacket(int widgetId, int childId)
 	{
 		return ClientPackets.INSTANCE.createContinuePacket(widgetId, childId);
+	}
+
+	public static void widgetAction(Widget widget, String action)
+	{
+		var actions = widget.getRawActions();
+		if (actions == null)
+		{
+			return;
+		}
+
+		var index = List.of(actions).indexOf(action);
+		if (index == 0) {
+			widgetFirstOption(widget);
+		} else if (index == 1) {
+			widgetSecondOption(widget);
+		} else if (index == 2) {
+			widgetThirdOption(widget);
+		} else if (index == 3) {
+			widgetFourthOption(widget);
+		} else if (index == 4) {
+			widgetFifthOption(widget);
+		} else if (index == 5) {
+			widgetSixthOption(widget);
+		} else if (index == 6) {
+			widgetSeventhOption(widget);
+		} else if (index == 7) {
+			widgetEighthOption(widget);
+		} else if (index == 8) {
+			widgetNinthOption(widget);
+		} else if (index == 9) {
+			widgetTenthOption(widget);
+		}
 	}
 }

--- a/app/src/main/java/dev/hoot/api/widgets/Prayers.java
+++ b/app/src/main/java/dev/hoot/api/widgets/Prayers.java
@@ -1,0 +1,49 @@
+package dev.hoot.api.widgets;
+
+import dev.hoot.api.game.Skills;
+import dev.hoot.api.game.Vars;
+import meteor.api.ClientPackets;
+import net.runelite.api.Prayer;
+import net.runelite.api.Skill;
+import net.runelite.api.Varbits;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+
+public class Prayers
+{
+	public static boolean isEnabled(Prayer prayer)
+	{
+		return Vars.getBit(prayer.varbit) == 1;
+	}
+
+	public static void toggle(Prayer prayer)
+	{
+
+		Widget widget = Widgets. get(prayer.widgetInfo);
+		if (widget != null)
+		{
+			widget.interact(0);
+		}
+	}
+
+	public static int getPoints()
+	{
+		return Skills.getBoostedLevel(Skill.PRAYER);
+	}
+
+	public static void toggleQuickPrayer(boolean enabled)
+	{
+		Widget widget = Widgets.get(WidgetInfo.MINIMAP_QUICK_PRAYER_ORB);
+		if (widget != null)
+		{
+			ClientPackets.INSTANCE.queueClickPacket(widget.getClickPoint());
+			widget.interact(enabled ? "Activate" : "Deactivate");
+		}
+
+	}
+
+	public static boolean isQuickPrayerEnabled()
+	{
+		return Vars.getBit(Varbits.QUICK_PRAYER) == 1;
+	}
+}

--- a/app/src/main/java/meteor/Main.kt
+++ b/app/src/main/java/meteor/Main.kt
@@ -135,7 +135,7 @@ class Main : AppCompatActivity() {
         // load configs immediately
         ConfigManager.loadSavedProperties()
         ConfigManager.setDefaultConfiguration(MeteorConfig::class.java, false)
-        ConfigManager.setDefaultConfiguration(PrivateServerConfig::class.java, false)
+        ConfigManager.setDefaultConfiguration(PrivateServerConfig::class.java, true)
         ConfigManager.saveProperties()
 
         // init meteor config

--- a/app/src/main/java/meteor/config/ConfigItem.kt
+++ b/app/src/main/java/meteor/config/ConfigItem.kt
@@ -35,6 +35,7 @@ class ConfigItem<T>(val config: Config,
                            val composePanel: Boolean = false,
                            val min: Int = -1,
                            val max: Int = -1,
+                           val alpha: Boolean = false,
                            val secret: Boolean = false) {
 
     init {

--- a/app/src/main/java/meteor/plugins/PluginManager.kt
+++ b/app/src/main/java/meteor/plugins/PluginManager.kt
@@ -5,11 +5,13 @@ import meteor.Main
 import meteor.config.ConfigManager
 import meteor.plugins.agility.AgilityPlugin
 import meteor.plugins.autologin.AutoLoginPlugin
+import meteor.plugins.interacthighlight.InteractHighlightPlugin
 import meteor.plugins.meteor.MeteorPlugin
 import meteor.plugins.mousetooltips.MouseTooltipPlugin
 import meteor.plugins.neverlog.NeverLogoutPlugin
 import meteor.plugins.onetapagility.OneTapAgilityPlugin
 import meteor.plugins.playeroutline.PlayerOutlinePlugin
+import meteor.plugins.prayerflicker.PrayerFlickerPlugin
 import meteor.plugins.privateserver.PrivateServerPlugin
 import meteor.plugins.reportbutton.ReportButtonPlugin
 import meteor.plugins.statusbars.StatusBarsPlugin
@@ -30,10 +32,12 @@ object PluginManager {
             init<MeteorPlugin>()
             init<AgilityPlugin>()
             init<AutoLoginPlugin>()
+            init<InteractHighlightPlugin>()
             init<MouseTooltipPlugin>()
             init<NeverLogoutPlugin>()
             init<OneTapAgilityPlugin>()
             init<PlayerOutlinePlugin>()
+            init<PrayerFlickerPlugin>()
             init<PrivateServerPlugin>()
             init<ReportButtonPlugin>()
             init<StatusBarsPlugin>()

--- a/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightConfig.kt
+++ b/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightConfig.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package meteor.plugins.interacthighlight
+
+import meteor.config.Config
+import meteor.config.legacy.*
+import java.awt.Color
+
+
+class InteractHighlightConfig : Config("interacthighlight") {
+
+    val npcShowHover = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcShowHover",
+            name = "Show on hover",
+            description = "Outline NPCs when hovered",
+            section = "NPCs",
+            defaultValue = true
+    )
+
+    val npcShowInteract = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcShowInteract",
+            name = "Show on interact",
+            description = "Outline NPCs when interacted",
+            section = "NPCs",
+            defaultValue = true,
+    )
+
+    val npcHoverHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcHoverHighlightColor",
+            name = "NPC hover",
+            description = "The color of the hover outline for NPCs",
+            section = "NPCs",
+            alpha = true,
+            defaultValue = Color(-0x6f000100, true),
+    )
+
+    val npcAttackHoverHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcAttackHoverHighlightColor",
+            name = "NPC attack hover",
+            description = "The color of the attack hover outline for NPCs",
+            section = "NPCs",
+            alpha = true,
+            defaultValue = Color(-0x6f000100, true),
+    )
+
+    val npcInteractHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcInteractHighlightColor",
+            name = "NPC interact",
+            description = "The color of the target outline for NPCs",
+            section = "NPCs",
+            alpha = true,
+            defaultValue = Color(-0x6f010000, true),
+    )
+
+    val npcAttackHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "npcAttackHighlightColor",
+            name = "NPC attack",
+            description = "The color of the outline on attacked NPCs",
+            section = "NPCs",
+            alpha = true,
+            defaultValue = Color(-0x6f010000, true),
+    )
+
+    val objectShowHover = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "objectShowHover",
+            name = "Show on hover",
+            description = "Outline objects when hovered",
+            section = "Objects",
+            defaultValue = true,
+    )
+
+    val objectShowInteract = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "objectShowInteract",
+            name = "Show on interact",
+            description = "Outline objects when interacted",
+            section = "Objects",
+            defaultValue = true,
+    )
+
+    val objectHoverHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "objectHoverHighlightColor",
+            name = "Object hover",
+            description = "The color of the hover outline for objects",
+            section = "Objects",
+            alpha = true,
+            defaultValue = Color(-0x6fff0001, true),
+    )
+
+    val objectInteractHighlightColor = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "objectInteractHighlightColor",
+            name = "Object interact",
+            description = "The color of the target outline for objects",
+            section = "Objects",
+            alpha = true,
+            defaultValue = Color(-0x6f010000, true),
+    )
+
+    val borderWidth = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "borderWidth",
+            name = "Border Width",
+            description = "Width of the outlined border",
+            defaultValue = 4,
+    )
+
+    val outlineFeather = meteor.config.ConfigItem(
+            this,
+            group = group,
+            keyName = "outlineFeather",
+            name = "Outline feather",
+            description = "Specify between 0-4 how much of the model outline should be faded",
+            defaultValue = 4,
+    )
+}

--- a/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightOverlay.kt
+++ b/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightOverlay.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2021, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package meteor.plugins.interacthighlight
+
+import meteor.ui.overlay.Overlay
+import meteor.ui.overlay.OverlayLayer
+import meteor.ui.overlay.OverlayPosition
+import meteor.ui.overlay.OverlayPriority
+import meteor.util.ColorUtil
+import net.runelite.api.MenuAction
+import net.runelite.api.MenuEntry
+import net.runelite.api.NPC
+import net.runelite.api.TileObject
+import net.runelite.api.widgets.WidgetID
+import net.runelite.api.widgets.WidgetInfo
+import meteor.outline.ModelOutlineRenderer
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Graphics2D
+
+internal class InteractHighlightOverlay(
+
+    private val plugin: InteractHighlightPlugin,
+
+    ) : Overlay() {
+
+    private var config = plugin.configuration<InteractHighlightConfig>()
+
+    private val modelOutlineRenderer = ModelOutlineRenderer()
+
+    init {
+
+        position = OverlayPosition.DYNAMIC
+        layer = OverlayLayer.ABOVE_SCENE
+        priority = OverlayPriority.HIGH
+    }
+
+    override fun render(graphics: Graphics2D): Dimension? {
+        try {
+            renderMouseover()
+            renderTarget()
+        } catch (_: Exception) {}
+        return null
+    }
+
+    private fun renderMouseover() {
+        val menuEntries: Array<MenuEntry> = client.menuEntries
+        if (menuEntries.size == 0) {
+            return
+        }
+        val entry: MenuEntry =
+            if (client.isMenuOpen) hoveredMenuEntry(menuEntries) else menuEntries[menuEntries.size - 1]
+        val menuAction: MenuAction = entry.type
+        when (menuAction) {
+            MenuAction.ITEM_USE_ON_GAME_OBJECT, MenuAction.WIDGET_TARGET_ON_GAME_OBJECT, MenuAction.GAME_OBJECT_FIRST_OPTION, MenuAction.GAME_OBJECT_SECOND_OPTION, MenuAction.GAME_OBJECT_THIRD_OPTION, MenuAction.GAME_OBJECT_FOURTH_OPTION, MenuAction.GAME_OBJECT_FIFTH_OPTION, MenuAction.EXAMINE_OBJECT -> {
+                val x: Int = entry.param0
+                val y: Int = entry.param1
+                val id: Int = entry.identifier
+                val tileObject: TileObject? = plugin.findTileObject(x, y, id)
+                if (tileObject != null && config.objectShowHover.get()!! && (tileObject !== plugin.interactedObject || !config.objectShowInteract.get()!!)) {
+                    modelOutlineRenderer.drawOutline(
+                        tileObject,
+                        config.borderWidth.get()!!,
+                        config.objectHoverHighlightColor.get()!!,
+                        config.outlineFeather.get()!!
+                    )
+                }
+            }
+            MenuAction.ITEM_USE_ON_NPC, MenuAction.WIDGET_TARGET_ON_NPC, MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION, MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION, MenuAction.EXAMINE_NPC -> {
+                val id: Int = entry.identifier
+                val npc = plugin.findNpc(id)
+                if (npc != null && config.npcShowHover.get()!! && (npc !== plugin.interactedTarget || !config.npcShowInteract.get()!!)) {
+                    val highlightColor = if (menuAction == MenuAction.NPC_SECOND_OPTION
+                        || menuAction == MenuAction.WIDGET_TARGET_ON_NPC && WidgetInfo.TO_GROUP(
+                            client.selectedWidget!!.id
+                        ) == WidgetID.SPELLBOOK_GROUP_ID
+                    ) config.npcAttackHoverHighlightColor.get()!! else config.npcHoverHighlightColor.get()!!
+                    modelOutlineRenderer.drawOutline(npc, config.borderWidth.get()!!, highlightColor, config.outlineFeather.get()!!)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    private fun renderTarget() {
+        val interactedObject: TileObject? = plugin.interactedObject
+        if (interactedObject != null && config.objectShowInteract.get()!!) {
+            val clickColor = getClickColor(
+                config.objectHoverHighlightColor.get()!!, config.objectInteractHighlightColor.get()!!,
+                (
+                        client.gameCycle - plugin.gameCycle).toLong()
+            )
+            modelOutlineRenderer.drawOutline(
+                interactedObject,
+                config.borderWidth.get()!!,
+                clickColor,
+                config.outlineFeather.get()!!
+            )
+        }
+        val target = plugin.interactedTarget
+        if (target is NPC && config.npcShowInteract.get()!!) {
+            val startColor =
+                if (plugin.attacked) config.npcAttackHoverHighlightColor.get()!! else config.npcHoverHighlightColor.get()!!
+            val endColor =
+                if (plugin.attacked) config.npcAttackHighlightColor.get()!! else config.npcInteractHighlightColor.get()!!
+            val clickColor = getClickColor(
+                startColor, endColor,
+                (
+                        client.gameCycle - plugin.gameCycle).toLong()
+            )
+            modelOutlineRenderer.drawOutline(target as NPC?, config.borderWidth.get()!!, clickColor, config.outlineFeather.get()!!)
+        }
+    }
+
+    private fun getClickColor(start: Color?, end: Color?, time: Long): Color? {
+        if (time < 5) {
+            return ColorUtil.colorLerp(start!!, INTERACT_CLICK_COLOR, (time / 5f).toDouble())
+        } else if (time < 10) {
+            return ColorUtil.colorLerp(INTERACT_CLICK_COLOR, end!!, ((time - 5) / 5f).toDouble())
+        }
+        return end
+    }
+
+    private fun hoveredMenuEntry(menuEntries: Array<MenuEntry>): MenuEntry {
+        val menuX = client.menuX
+        val menuY = client.menuY
+        val menuWidth = client.menuWidth
+        val mousePosition = client.mouseCanvasPosition
+        var dy = mousePosition.y - menuY
+        dy -= 19 // Height of Choose Option
+        if (dy < 0) {
+            return menuEntries[menuEntries.size - 1]
+        }
+        var idx = dy / 15 // Height of each menu option
+        idx = menuEntries.size - 1 - idx
+        return if (mousePosition.x > menuX && mousePosition.x < menuX + menuWidth && idx >= 0 && idx < menuEntries.size) {
+            menuEntries[idx]
+        } else menuEntries[menuEntries.size - 1]
+    }
+
+    companion object {
+        private val INTERACT_CLICK_COLOR = Color(-0x6f000001)
+    }
+}

--- a/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightPlugin.kt
+++ b/app/src/main/java/meteor/plugins/interacthighlight/InteractHighlightPlugin.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package meteor.plugins.interacthighlight
+
+import eventbus.events.*
+import lombok.AccessLevel
+import lombok.Getter
+import meteor.plugins.Plugin
+import meteor.plugins.PluginDescriptor
+import net.runelite.api.*
+import net.runelite.api.widgets.WidgetID
+import net.runelite.api.widgets.WidgetInfo
+
+@Suppress("DEPRECATION")
+@PluginDescriptor(
+    name = "Interact Highlight",
+    description = "Outlines npcs and objects you interact with or hover over",
+    enabledByDefault = false
+)
+class InteractHighlightPlugin : Plugin() {
+    val config: InteractHighlightConfig = configuration()
+    private val interactHighlightOverlay = overlay(InteractHighlightOverlay(this))
+
+    @Getter(AccessLevel.PACKAGE)
+    var interactedObject: TileObject? = null
+    private var interactedNpc: NPC? = null
+
+    @Getter(AccessLevel.PACKAGE)
+    var attacked = false
+    private var clickTick = 0
+
+    @Getter(AccessLevel.PACKAGE)
+    var gameCycle = 0
+    override fun onGameStateChanged(it: GameStateChanged) {
+        if (it.gameState == GameState.LOADING) {
+            interactedObject = null
+        }
+    }
+
+    override fun onNpcDespawned(it: NpcDespawned) {
+        if (it.npc === interactedNpc) {
+            interactedNpc = null
+        }
+    }
+
+    override fun onGameTick(it: GameTick) {
+        if (client.tickCount > clickTick && client.localDestinationLocation == null) {
+            // when the destination is reached, clear the interacting object
+            interactedObject = null
+            interactedNpc = null
+        }
+    }
+
+    override fun onInteractingChanged(it: InteractingChanged) {
+        if (it.source === client.localPlayer && client.tickCount > clickTick && it.target !== interactedNpc) {
+            interactedNpc = null
+            attacked = it.target != null && it.target!!.combatLevel > 0
+        }
+    }
+
+    override fun onMenuOptionClicked(it: MenuOptionClicked) {
+        when (it.getMenuAction()) {
+            MenuAction.ITEM_USE_ON_GAME_OBJECT, MenuAction.WIDGET_TARGET_ON_GAME_OBJECT, MenuAction.GAME_OBJECT_FIRST_OPTION, MenuAction.GAME_OBJECT_SECOND_OPTION, MenuAction.GAME_OBJECT_THIRD_OPTION, MenuAction.GAME_OBJECT_FOURTH_OPTION, MenuAction.GAME_OBJECT_FIFTH_OPTION -> {
+                val x = it.getParam0()
+                val y = it.getParam1()
+                val id = it.getId()
+                interactedObject = findTileObject(x, y, id)
+                interactedNpc = null
+                clickTick = client.tickCount
+                gameCycle = client.gameCycle
+            }
+            MenuAction.ITEM_USE_ON_NPC, MenuAction.WIDGET_TARGET_ON_NPC, MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION, MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION -> {
+                val id = it.getId()
+                interactedObject = null
+                interactedNpc = findNpc(id)
+                attacked = it.getMenuAction() == MenuAction.NPC_SECOND_OPTION ||
+                        it.getMenuAction() == MenuAction.WIDGET_TARGET_ON_NPC && WidgetInfo.TO_GROUP(
+                    client.selectedWidget!!.id
+                ) == WidgetID.SPELLBOOK_GROUP_ID
+                clickTick = client.tickCount
+                gameCycle = client.gameCycle
+            }
+            MenuAction.WALK, MenuAction.ITEM_USE, MenuAction.WIDGET_TARGET_ON_WIDGET, MenuAction.ITEM_USE_ON_GROUND_ITEM, MenuAction.WIDGET_TARGET_ON_GROUND_ITEM, MenuAction.ITEM_USE_ON_PLAYER, MenuAction.WIDGET_TARGET_ON_PLAYER, MenuAction.ITEM_FIRST_OPTION, MenuAction.ITEM_SECOND_OPTION, MenuAction.ITEM_THIRD_OPTION, MenuAction.ITEM_FOURTH_OPTION, MenuAction.ITEM_FIFTH_OPTION, MenuAction.GROUND_ITEM_FIRST_OPTION, MenuAction.GROUND_ITEM_SECOND_OPTION, MenuAction.GROUND_ITEM_THIRD_OPTION, MenuAction.GROUND_ITEM_FOURTH_OPTION, MenuAction.GROUND_ITEM_FIFTH_OPTION -> {
+                interactedObject = null
+                interactedNpc = null
+            }
+            else -> if (it.isItemOp()) {
+                interactedObject = null
+                interactedNpc = null
+            }
+        }
+    }
+
+    fun findTileObject(x: Int, y: Int, id: Int): TileObject? {
+        val scene = client.scene
+        val tiles = scene.tiles
+        val tile = tiles[client.plane][x][y]
+        if (tile != null) {
+            for (gameObject in tile.gameObjects) {
+                if (gameObject != null && gameObject.id == id) {
+                    return gameObject
+                }
+            }
+            val wallObject = tile.wallObject
+            if (wallObject != null && wallObject.id == id) {
+                return wallObject
+            }
+            val decorativeObject = tile.decorativeObject
+            if (decorativeObject != null && decorativeObject.id == id) {
+                return decorativeObject
+            }
+            val groundObject = tile.groundObject
+            if (groundObject != null && groundObject.id == id) {
+                return groundObject
+            }
+        }
+        return null
+    }
+
+    fun findNpc(id: Int): NPC? {
+
+        return client.cachedNPCs[id]
+    }
+
+    val interactedTarget: Actor?
+        get() = if (interactedNpc != null) interactedNpc else client.localPlayer!!.interacting
+}

--- a/app/src/main/java/meteor/plugins/prayerflicker/PrayerFlickerPlugin.kt
+++ b/app/src/main/java/meteor/plugins/prayerflicker/PrayerFlickerPlugin.kt
@@ -1,0 +1,120 @@
+package meteor.plugins.prayerflicker
+
+import dev.hoot.api.packets.WidgetPackets
+import dev.hoot.api.widgets.Prayers
+import dev.hoot.api.widgets.Widgets
+import eventbus.events.ClientTick
+import eventbus.events.GameTick
+import eventbus.events.MenuOptionClicked
+import meteor.Main
+import meteor.api.ClientPackets
+import meteor.plugins.Plugin
+import meteor.plugins.PluginDescriptor
+import meteor.rs.ClientThread
+import meteor.util.ColorUtil.wrapWithColorTag
+import net.runelite.api.GameState
+import net.runelite.api.MenuAction
+import net.runelite.api.Varbits
+import net.runelite.api.widgets.WidgetInfo
+import java.awt.Color
+import java.awt.Point
+
+
+@PluginDescriptor(name = "Prayer Flicker", description = "prayer flicker for quick prayers", enabledByDefault = false)
+class PrayerFlickerPlugin : Plugin() {
+
+    var toggle = false
+    lateinit var clickPoint: Point
+
+    private val quickPrayerWidgetID = WidgetInfo.MINIMAP_QUICK_PRAYER_ORB
+
+    private fun togglePrayer() {
+        val quickPrayerOrb = Widgets.get(quickPrayerWidgetID)
+        if (!this::clickPoint.isInitialized)
+            clickPoint = quickPrayerOrb.clickPoint
+        ClientPackets.queueClickPacket(clickPoint)
+        WidgetPackets.widgetAction(quickPrayerOrb, "Activate")
+        ClientPackets.queueClickPacket(clickPoint)
+        WidgetPackets.widgetAction(quickPrayerOrb, "Deactivate")
+    }
+
+    override fun onStop() {
+        toggle = false
+    }
+
+    override fun onGameTick(it: GameTick) {
+        if(Main.client.gameState == GameState.LOGGED_IN && client.localPlayer != null)
+        if (Prayers.getPoints() == 0){
+            toggle = false
+        }
+
+        if (toggle) {
+            val quickPrayer = client.getVarbitValue(Varbits.QUICK_PRAYER) == 1
+            if (quickPrayer) {
+
+                togglePrayer()
+            }
+            togglePrayer()
+        }
+    }
+
+
+    fun toggleFlicker(on: Boolean) {
+        toggle = on
+
+        if (!toggle) {
+            ClientThread.invoke {
+                if (Prayers.isQuickPrayerEnabled()) {
+                    togglePrayer()
+                }
+            }
+        }
+    }
+
+
+    override fun onClientTick(it: ClientTick) {
+        val menuEntries = client.menuEntries
+        for (entry in menuEntries) {
+            if (entry.param1 == quickPrayerWidgetID.packedId) {
+                addMenuEntry()
+                return
+            }
+        }
+    }
+
+    var target = wrapWithColorTag("Prayer Flicker", Color.GREEN)
+    private fun addMenuEntry() {
+        //Stop action takes priority via opcode
+        val action: String
+        val opcode: Int
+        if (toggle) {
+            action = "Stop"
+            opcode = MenuAction.UNKNOWN.id
+        } else {
+            action = "Start"
+            opcode = MenuAction.UNKNOWN.id
+        }
+        client.insertMenuItem(
+            action,
+            target,
+            opcode,
+            1,
+            -1,
+            -1,
+            false
+        )
+    }
+
+
+    override fun onMenuOptionClicked(it: MenuOptionClicked) {
+        if ((it.getMenuAction() == MenuAction.RUNELITE || it.getMenuAction() == MenuAction.UNKNOWN) && it.getMenuTarget() == target) {
+            if (it.getMenuOption() == "Start") {
+                toggleFlicker(true)
+            }
+            if (it.getMenuOption() == "Stop") {
+                toggleFlicker(false)
+            }
+            it.consume()
+        }
+    }
+}


### PR DESCRIPTION
Prayer Flicker has had the Start menu entry moved to the top, very easy to toggle flicking without opening a menu.  
I plan to support floating buttons for things like this for better control.  
Interact Highlight really only works for with a stylus that supports hovering (I test with S-Pen)  
  
I also made RSPS config overwrite default value in settings on startup (this makes changing values during development easier.  
This won't remain default behavior when the client is more polished  